### PR TITLE
os-restart: don't exit prematurely if the kill fails

### DIFF
--- a/os-restart.sh
+++ b/os-restart.sh
@@ -1,7 +1,9 @@
-#!/bin/bash -e
+#!/bin/bash
 
 echo "[INFO] Killing OpenShift..."
 sudo pkill openshift
+
+set -e
 
 echo "[INFO] Starting OpenShift..."
 loglevel=${1:-0}


### PR DESCRIPTION
If you bounce a machine and then use the os-restart.sh script to bring
everything back up the initial `sudo pkill openshift` exits with
EXIT_FAILURE (because it's not actually running), and the -e on the
bash script will then exit immediately. This means that os-restart.sh
doesn't actually restart; fixed by moving the `set -error` to after
the `pkill openshift`.

Signed-off-by: Andrew McDermott <aim@frobware.com>